### PR TITLE
AI talks first and Server VAD preemption and interruption

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,3 +74,13 @@ node index.js
 ```
 ## Test the app
 With the development server running, call the phone number you purchases in the **Prerequisites**. After the introduction, you should be able to talk to the AI Assistant. Have fun!
+
+## Special features
+
+### Have the AI speak first
+To have the AI voice assistant talk before the user, uncomment the line `// sendInitialConversationItem();`. The initial greeting is controlled in `sendInitialConversationItem`.
+
+### Interrupt handling/AI preemption
+When the user speaks and OpenAI sends `input_audio_buffer.speech_started`, the code will clear the Twilio Media Streams buffer and send OpenAI `conversation.item.truncate`.
+
+Depending on your application's needs, you may want to use the [`input_audio_buffer.speech_stopped`](https://platform.openai.com/docs/api-reference/realtime-server-events/input-audio-buffer-speech-stopped) event, instead.

--- a/Readme.md
+++ b/Readme.md
@@ -74,3 +74,13 @@ node index.js
 ```
 ## Test the app
 With the development server running, call the phone number you purchased in the **Prerequisites**. After the introduction, you should be able to talk to the AI Assistant. Have fun!
+
+## Special features
+
+### Have the AI speak first
+To have the AI voice assistant talk before the user, uncomment the line `// sendInitialConversationItem();`. The initial greeting is controlled in `sendInitialConversationItem`.
+
+### Interrupt handling/AI preemption
+When the user speaks and OpenAI sends `input_audio_buffer.speech_started`, the code will clear the Twilio Media Streams buffer and send OpenAI `conversation.item.truncate`.
+
+Depending on your application's needs, you may want to use the [`input_audio_buffer.speech_stopped`](https://platform.openai.com/docs/api-reference/realtime-server-events/input-audio-buffer-speech-stopped) event, instead.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speech-assistant-openai-realtime-api-node",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR aims to add two new features to this demo.

- **AI talks first.** Uncomment `sendInitialConversationItem();` to test.
- **Interrupt AI and truncate conversation.** To test:
  - Ask the AI to count to 20
  - Interrupt somewhere around 5-8 by saying "Wait stop.... how far did you get before I interrupted you?"
  - AI should state 5-8, plus or minus two (due to minor timing differences with interrupt timing, and the `response.audio.delta` audio we send to Twilio).
  - _Note:_ if you interrupt more than once, you may need to clarify with the AI which interruption. It is very literal and will often reference the first.